### PR TITLE
Add EpiNow2 submission

### DIFF
--- a/.github/workflows/automate_epinow2.yml
+++ b/.github/workflows/automate_epinow2.yml
@@ -13,10 +13,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    
-    - uses: r-lib/actions/setup-r@v1
-      with:
-        use-public-rspm: true
 
     - name: Install system dependencies
       run: sudo apt-get install libudunits2-dev libcurl4-openssl-dev

--- a/.github/workflows/automate_epinow2.yml
+++ b/.github/workflows/automate_epinow2.yml
@@ -19,12 +19,7 @@ jobs:
         use-public-rspm: true
 
     - name: Install system dependencies
-      run: sudo apt-get install libudunits2-dev libcurl4-openssl-dev libgdal-dev libv8-dev
-
-    - name: Install R dependencies
-      run: |
-       install.packages(c("fread", "glue"))
-      shell: Rscript {0}
+      run: sudo apt-get install libudunits2-dev libcurl4-openssl-dev
 
     - name: Generate forecasts
       run: data-submission/epinow2/main.sh

--- a/.github/workflows/automate_epinow2.yml
+++ b/.github/workflows/automate_epinow2.yml
@@ -12,13 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
-
-    - name: Install system dependencies
-      run: sudo apt-get install libudunits2-dev libcurl4-openssl-dev
+        submodules: false
 
     - name: Generate forecasts
-      run: data-submission/epinow2/main.sh
+      run: data-submissions/epinow2/main.sh
       shell: bash
       
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/automate_epinow2.yml
+++ b/.github/workflows/automate_epinow2.yml
@@ -1,0 +1,111 @@
+name: "Automation"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 13 * * 2"
+
+jobs:
+  generate-forecasts:
+    runs-on: ubuntu-20.04
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    
+    - uses: r-lib/actions/setup-r@v1
+      with:
+        use-public-rspm: true
+
+    - name: Install system dependencies
+      run: sudo apt-get install libudunits2-dev libcurl4-openssl-dev libgdal-dev libv8-dev
+
+    - name: Install R dependencies
+      run: |
+       install.packages(c("fread", "glue"))
+      shell: Rscript {0}
+
+    - name: Generate forecasts
+      run: |
+        library(glue)
+        library(data.table)
+        dir.create("models/epinow2")
+        date <- Sys.Date()
+        url <- glue("https://raw.githubusercontent.com/epiforecasts/europe-covid-forecast/master/submissions/rt-forecasts/{date}/{date}-epiforecasts-EpiNow2.csv")
+        forecast <- fread(url)
+        fwrite(glue("models/epinow2/{date}-epiforecasts-EpiNow2.csv"))
+      shell: Rscript {0}
+      
+    - uses: actions/upload-artifact@v2
+      with:
+        name: epinow2
+        retention-days: 5
+        path: models/epinow2
+
+  upload-forecasts:
+    needs: generate-forecasts
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: r-lib/actions/setup-r@v1
+      with:
+        use-public-rspm: true
+
+    - name: Install system libraries
+      run: |
+        sudo apt-get install libcurl4-openssl-dev
+  
+    - name: Install helper R package
+      env:
+        GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        install.packages("remotes")
+        remotes::install_github("epiforecasts/covid19-forecast-hub-europe-submissions")
+      shell: Rscript {0}
+      
+    - name: Create new branch
+      env: 
+        GITHUB_PAT: ${{ secrets.EPIFORECASTS_TOKEN }}
+      run: |
+        ForecastHubAutosubmissions::create_github_branch(
+          new_branch = "epinow2",
+          gh_user = "epiforecasts",
+          gh_repo = "covid19-forecast-hub-europe"
+        )
+      shell: Rscript {0}
+    
+    - uses: actions/checkout@v2
+      with: 
+        repository: 'epiforecasts/covid19-forecast-hub-europe'
+        ref: 'epinow2'
+        token: ${{ secrets.EPIFORECASTS_TOKEN }}
+    
+    - uses: actions/download-artifact@v2
+      with:
+        name: epinow2
+        path: data-processed/epiforecasts-EpiNow2
+        
+    - name: Commit and push
+      run: |
+        git config user.email "action@github.com"
+        git config user.name "GitHub Action - Visualisation Update"
+        git add --all
+        git commit -m "EpiNow2 automated submission"
+        git push
+        echo "pushed to github"
+        
+    - name: Open pull request
+      env: 
+        GITHUB_PAT: ${{ secrets.EPIFORECASTS_TOKEN }}
+      run: |
+        gh::gh(
+          "POST /repos/{owner}/{repo}/pulls", 
+          owner = "epiforecasts",
+          repo = "covid19-forecast-hub-europe",
+          title = "EpiNow2 automated submission",
+          head = "epinow2",
+          base = "main"
+        )
+      shell: Rscript {0}
+

--- a/.github/workflows/automate_epinow2.yml
+++ b/.github/workflows/automate_epinow2.yml
@@ -34,7 +34,7 @@ jobs:
         date <- Sys.Date()
         url <- glue("https://raw.githubusercontent.com/epiforecasts/europe-covid-forecast/master/submissions/rt-forecasts/{date}/{date}-epiforecasts-EpiNow2.csv")
         forecast <- fread(url)
-        fwrite(glue("models/epinow2/{date}-epiforecasts-EpiNow2.csv"))
+        fwrite(forecast, glue("models/epinow2/{date}-epiforecasts-EpiNow2.csv"))
       shell: Rscript {0}
       
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/automate_epinow2.yml
+++ b/.github/workflows/automate_epinow2.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         name: epinow2
         retention-days: 5
-        path: data-submission/epinow2
+        path: data-submissions/epinow2
 
   upload-forecasts:
     needs: generate-forecasts

--- a/.github/workflows/automate_epinow2.yml
+++ b/.github/workflows/automate_epinow2.yml
@@ -27,21 +27,14 @@ jobs:
       shell: Rscript {0}
 
     - name: Generate forecasts
-      run: |
-        library(glue)
-        library(data.table)
-        dir.create("models/epinow2", recursive = TRUE)
-        date <- Sys.Date()
-        url <- glue("https://raw.githubusercontent.com/epiforecasts/europe-covid-forecast/master/submissions/rt-forecasts/{date}/{date}-epiforecasts-EpiNow2.csv")
-        forecast <- fread(url)
-        fwrite(forecast, glue("models/epinow2/{date}-epiforecasts-EpiNow2.csv"))
-      shell: Rscript {0}
+      run: data-submission/epinow2/main.sh
+      shell: bash
       
     - uses: actions/upload-artifact@v2
       with:
         name: epinow2
         retention-days: 5
-        path: models/epinow2
+        path: data-submission/epinow2
 
   upload-forecasts:
     needs: generate-forecasts

--- a/.github/workflows/automate_epinow2.yml
+++ b/.github/workflows/automate_epinow2.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         library(glue)
         library(data.table)
-        dir.create("models/epinow2")
+        dir.create("models/epinow2", recursive = TRUE)
         date <- Sys.Date()
         url <- glue("https://raw.githubusercontent.com/epiforecasts/europe-covid-forecast/master/submissions/rt-forecasts/{date}/{date}-epiforecasts-EpiNow2.csv")
         forecast <- fread(url)

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+*.csv

--- a/README.Rmd
+++ b/README.Rmd
@@ -48,4 +48,4 @@ To submit your model for auto-submission, you need to [open an issue](https://gi
 Please note that although encouraged, it is not strictly mandatory to submit the
 code generating your forecasts. You can submit a script fetching already 
 existing forecasts from another location such as an API, another GitHub 
-repository, a data repository, etc.
+repository, a data repository, etc.∂

--- a/README.Rmd
+++ b/README.Rmd
@@ -48,4 +48,4 @@ To submit your model for auto-submission, you need to [open an issue](https://gi
 Please note that although encouraged, it is not strictly mandatory to submit the
 code generating your forecasts. You can submit a script fetching already 
 existing forecasts from another location such as an API, another GitHub 
-repository, a data repository, etc.∂
+repository, a data repository, etc.

--- a/data-submissions/epinow2/main.sh
+++ b/data-submissions/epinow2/main.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+TODAY=$(date +'%Y-%m-%d')
+wget -P data-submissions/epinow2 https://raw.githubusercontent.com/epiforecasts/europe-covid-forecast/master/submissions/rt-forecasts/$TODAY/$TODAY-epiforecasts-EpiNow2.csv


### PR DESCRIPTION
Adds an automated submission for EpiNow2. Rather than using a submodule this action simply downloads the forecast from a dated URL and then copies the other parts of the workflow to PR this into the hub repository. 

Note I wrote this using github.dev so likely a bit dodgy. Happy to improve under direction (for example writing this in a script vs inline in the action). 